### PR TITLE
Handle custom pydantic model field color types

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -403,8 +403,8 @@ def test_custom_color_dict():
     )
 
     # test with custom color dict
-    assert type(layer.get_color(2)) == np.ndarray
-    assert type(layer.get_color(1)) == np.ndarray
+    assert isinstance(layer.get_color(2), np.ndarray)
+    assert isinstance(layer.get_color(1), np.ndarray)
     assert (layer.get_color(2) == np.array([1.0, 1.0, 1.0, 1.0])).all()
     assert (layer.get_color(4) == layer.get_color(16)).all()
     assert (layer.get_color(8) == layer.get_color(32)).all()

--- a/napari/layers/surface/normals.py
+++ b/napari/layers/surface/normals.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 
 from pydantic import Field
 
-from napari.utils.color import ColorValueType
+from napari.utils.color import ColorValue
 from napari.utils.events import EventedModel
 
 
@@ -32,7 +32,7 @@ class Normals(EventedModel):
 
     mode: NormalMode = Field(NormalMode.FACE, allow_mutation=False)
     visible: bool = False
-    color: ColorValueType = 'black'
+    color: ColorValue = ColorValue('black')
     width: float = 1
     length: float = 5
 

--- a/napari/layers/surface/wireframe.py
+++ b/napari/layers/surface/wireframe.py
@@ -1,4 +1,4 @@
-from napari.utils.color import ColorValueType
+from napari.utils.color import ColorValue
 from napari.utils.events import EventedModel
 
 
@@ -18,5 +18,5 @@ class SurfaceWireframe(EventedModel):
     """
 
     visible: bool = False
-    color: ColorValueType = 'black'
+    color: ColorValue = ColorValue('black')
     width: float = 1

--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -36,40 +36,40 @@ def test_calc_data_range():
     # all zeros should return [0, 1] by default
     data = np.zeros((10, 10))
     clim = calc_data_range(data)
-    assert np.all(clim == [0, 1])
+    assert clim == (0, 1)
 
     # all ones should return [0, 1] by default
     data = np.ones((10, 10))
     clim = calc_data_range(data)
-    assert np.all(clim == [0, 1])
+    assert clim == (0, 1)
 
     # return min and max
     data = np.random.random((10, 15))
     data[0, 0] = 0
     data[0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == [0, 2])
+    assert clim == (0, 2)
 
     # return min and max
     data = np.random.random((6, 10, 15))
     data[0, 0, 0] = 0
     data[0, 0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == [0, 2])
+    assert clim == (0, 2)
 
     # Try large data
     data = np.zeros((1000, 2000))
     data[0, 0] = 0
     data[0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == [0, 2])
+    assert clim == (0, 2)
 
     # Try large data mutlidimensional
     data = np.zeros((3, 1000, 1000))
     data[0, 0, 0] = 0
     data[0, 0, 1] = 2
     clim = calc_data_range(data)
-    assert np.all(clim == [0, 2])
+    assert clim == (0, 2)
 
 
 @pytest.mark.parametrize(

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -199,7 +199,7 @@ def _nanmax(array):
 
 
 def calc_data_range(data, rgb=False) -> Tuple[float, float]:
-    """Calculate range of data values. If all values are equal return [0, 1].
+    """Calculate range of data values. If all values are equal return (0, 1).
 
     Parameters
     ----------
@@ -210,8 +210,8 @@ def calc_data_range(data, rgb=False) -> Tuple[float, float]:
 
     Returns
     -------
-    values : tuple[float, float]
-        Range of values.
+    values : pair of floats
+        Minimum and maximum values in that order.
 
     Notes
     -----

--- a/napari/utils/color.py
+++ b/napari/utils/color.py
@@ -129,5 +129,5 @@ class ColorArray(np.ndarray):
         # Special case an empty supported sequence because transform_color
         # warns and returns an array containing a default color in that case.
         if isinstance(value, (np.ndarray, list, tuple)) and len(value) == 0:
-            return np.empty((0, 4), np.float32)
+            return np.empty((0, 4), np.float32).view(cls)
         return transform_color(value).view(cls)

--- a/napari/utils/color.py
+++ b/napari/utils/color.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from napari.utils.colormaps.standardize_color import transform_color
 
-ColorValueType = Union[np.ndarray, list, tuple, str, None]
+ColorValueParam = Union[np.ndarray, list, tuple, str, None]
+ColorArrayParam = Union[np.ndarray, list, tuple, None]
 
 
 class ColorValue(np.ndarray):
@@ -17,12 +18,15 @@ class ColorValue(np.ndarray):
     use the ``validate`` method to coerce a value to a single color.
     """
 
+    def __new__(cls, value: ColorValueParam):
+        return cls.validate(value)
+
     @classmethod
     def __get_validators__(cls):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value: ColorValueType) -> np.ndarray:
+    def validate(cls, value: ColorValueParam) -> 'ColorValue':
         """Validates and coerces the given value into an array storing one color.
 
         Parameters
@@ -67,7 +71,7 @@ class ColorValue(np.ndarray):
         >>> ColorValue.validate('#ff0000')
         array([1., 0., 0., 1.], dtype=float32)
         """
-        return transform_color(value)[0]
+        return transform_color(value)[0].view(cls)
 
 
 class ColorArray(np.ndarray):
@@ -78,14 +82,15 @@ class ColorArray(np.ndarray):
     use the ``validate`` method to coerce a value to an array of colors.
     """
 
+    def __new__(cls, value: ColorArrayParam):
+        return cls.validate(value)
+
     @classmethod
     def __get_validators__(cls):
         yield cls.validate
 
     @classmethod
-    def validate(
-        cls, value: Union[np.ndarray, list, tuple, None]
-    ) -> np.ndarray:
+    def validate(cls, value: ColorArrayParam) -> 'ColorArray':
         """Validates and coerces the given value into an array storing many colors.
 
         Parameters
@@ -125,4 +130,4 @@ class ColorArray(np.ndarray):
         # warns and returns an array containing a default color in that case.
         if isinstance(value, (np.ndarray, list, tuple)) and len(value) == 0:
             return np.empty((0, 4), np.float32)
-        return transform_color(value)
+        return transform_color(value).view(cls)

--- a/napari/utils/colormaps/standardize_color.py
+++ b/napari/utils/colormaps/standardize_color.py
@@ -62,7 +62,10 @@ def transform_color(colors: Any) -> np.ndarray:
         invalid inputs
     """
     colortype = type(colors)
-    return _color_switch[colortype](colors)
+    for typ, handler in _color_switch.items():
+        if issubclass(colortype, typ):
+            return handler(colors)
+    raise ValueError(f"cannot convert type '{colortype}' to a color array.")
 
 
 @functools.lru_cache(maxsize=1024)


### PR DESCRIPTION
This is a suggestion for https://github.com/napari/napari/pull/5871 that is mostly focused on the custom pydantic field types `ColorValue` and `ColorArray` that are used to handle coercion from supported input values.

This [idea originally came up for different reasons](https://github.com/napari/napari/pull/4704#discussion_r900289069) and  was almost added in https://github.com/napari/napari/pull/5060

Given that `ColorValue` and `ColorArray` are declared as subtypes of `ndarray`, this has the benefit of actually returning those subtypes (rather than just a plain array), which makes mypy happy too for understandable reasons. It also makes coercion slightly more ergonomic allowing for `ColorArray(...)` instead of `ColorArray.validate(...)`.

The main problem is the same as the benefit. Users than expected to see a plain `ndarray`, will now see something different. Though that thing is still a `ndarray` through inheritance, so I don't think this is a big problem.

This PR also makes a few small suggestions that should make some other tests pass.